### PR TITLE
Add unit tests for services

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
         "dev": "vite",
         "build": "tsc -b && vite build",
         "lint": "eslint .",
-        "preview": "vite preview"
+        "preview": "vite preview",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "test:coverage": "vitest run --coverage"
     },
     "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -35,17 +38,22 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.23.0",
+        "@testing-library/jest-dom": "^6.6.4",
+        "@testing-library/react": "^16.3.0",
         "@types/node": "^22.13.13",
         "@types/react": "^19.0.12",
         "@types/react-dom": "^19.0.4",
         "@types/react-helmet": "^6.1.11",
         "@vitejs/plugin-react": "^4.3.4",
+        "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.23.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^15.15.0",
+        "jsdom": "^26.1.0",
         "typescript": "~5.7.3",
         "typescript-eslint": "^8.28.0",
-        "vite": "^6.2.3"
+        "vite": "^6.2.3",
+        "vitest": "^3.2.4"
     }
 }

--- a/src/services/__tests__/appwrite.test.ts
+++ b/src/services/__tests__/appwrite.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { validateFileType, ALLOWED_IMAGE_TYPES, ALLOWED_DOCUMENT_TYPES } from '../appwrite';
+
+describe('appwrite service utilities', () => {
+  describe('validateFileType', () => {
+    it('should return true for allowed image types', () => {
+      ALLOWED_IMAGE_TYPES.forEach(type => {
+        const file = new File(['test content'], 'test.jpg', { type });
+        expect(validateFileType(file, ALLOWED_IMAGE_TYPES)).toBe(true);
+      });
+    });
+
+    it('should return true for allowed document types', () => {
+      ALLOWED_DOCUMENT_TYPES.forEach(type => {
+        const file = new File(['test content'], 'test.pdf', { type });
+        expect(validateFileType(file, ALLOWED_DOCUMENT_TYPES)).toBe(true);
+      });
+    });
+
+    it('should return false for disallowed types', () => {
+      const disallowedTypes = ['text/plain', 'application/javascript', 'text/html'];
+      
+      disallowedTypes.forEach(type => {
+        const file = new File(['test content'], 'test.txt', { type });
+        expect(validateFileType(file, ALLOWED_IMAGE_TYPES)).toBe(false);
+        expect(validateFileType(file, ALLOWED_DOCUMENT_TYPES)).toBe(false);
+      });
+    });
+
+    it('should return false when file type is empty', () => {
+      const file = new File(['test content'], 'test.unknown', { type: '' });
+      expect(validateFileType(file, ALLOWED_IMAGE_TYPES)).toBe(false);
+    });
+
+    it('should handle custom allowed types array', () => {
+      const customAllowedTypes = ['text/plain', 'text/csv'];
+      
+      // Should return true for allowed types
+      const textFile = new File(['test content'], 'test.txt', { type: 'text/plain' });
+      expect(validateFileType(textFile, customAllowedTypes)).toBe(true);
+      
+      // Should return false for disallowed types
+      const imageFile = new File(['test content'], 'test.jpg', { type: 'image/jpeg' });
+      expect(validateFileType(imageFile, customAllowedTypes)).toBe(false);
+    });
+  });
+});

--- a/src/services/__tests__/fileProxy.test.ts
+++ b/src/services/__tests__/fileProxy.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getFileUrl, getFilePreviewUrl, getFileDownloadUrl } from '../fileProxy';
+import { storage, STORAGE_FILE_BUCKET_ID } from '../appwrite';
+
+// Mock the appwrite storage module
+vi.mock('../appwrite', () => {
+  return {
+    storage: {
+      getFileView: vi.fn(),
+      getFilePreview: vi.fn(),
+      getFileDownload: vi.fn(),
+    },
+    STORAGE_FILE_BUCKET_ID: 'test-bucket-id',
+  };
+});
+
+describe('fileProxy service', () => {
+  const mockFileId = 'test-file-id';
+  const mockUrl = 'https://example.com/file';
+  
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Setup default mock implementations
+    (storage.getFileView as any).mockReturnValue(mockUrl);
+    (storage.getFilePreview as any).mockReturnValue(mockUrl);
+    (storage.getFileDownload as any).mockReturnValue(mockUrl);
+  });
+
+  describe('getFileUrl', () => {
+    it('should return the file URL from Appwrite storage', () => {
+      const result = getFileUrl(mockFileId);
+      
+      expect(storage.getFileView).toHaveBeenCalledWith(STORAGE_FILE_BUCKET_ID, mockFileId);
+      expect(result).toBe(mockUrl);
+    });
+
+    it('should return empty string when an error occurs', () => {
+      (storage.getFileView as any).mockImplementation(() => {
+        throw new Error('Test error');
+      });
+      
+      const result = getFileUrl(mockFileId);
+      
+      expect(storage.getFileView).toHaveBeenCalledWith(STORAGE_FILE_BUCKET_ID, mockFileId);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('getFilePreviewUrl', () => {
+    it('should return the file preview URL without dimensions', () => {
+      const result = getFilePreviewUrl(mockFileId);
+      
+      expect(storage.getFilePreview).toHaveBeenCalledWith(STORAGE_FILE_BUCKET_ID, mockFileId, undefined, undefined);
+      expect(result).toBe(mockUrl);
+    });
+
+    it('should return the file preview URL with dimensions', () => {
+      const width = 100;
+      const height = 200;
+      
+      const result = getFilePreviewUrl(mockFileId, width, height);
+      
+      expect(storage.getFilePreview).toHaveBeenCalledWith(STORAGE_FILE_BUCKET_ID, mockFileId, width, height);
+      expect(result).toBe(mockUrl);
+    });
+
+    it('should return empty string when an error occurs', () => {
+      (storage.getFilePreview as any).mockImplementation(() => {
+        throw new Error('Test error');
+      });
+      
+      const result = getFilePreviewUrl(mockFileId);
+      
+      expect(storage.getFilePreview).toHaveBeenCalledWith(STORAGE_FILE_BUCKET_ID, mockFileId, undefined, undefined);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('getFileDownloadUrl', () => {
+    it('should return the file download URL from Appwrite storage', () => {
+      const result = getFileDownloadUrl(mockFileId);
+      
+      expect(storage.getFileDownload).toHaveBeenCalledWith(STORAGE_FILE_BUCKET_ID, mockFileId);
+      expect(result).toBe(mockUrl);
+    });
+
+    it('should return empty string when an error occurs', () => {
+      (storage.getFileDownload as any).mockImplementation(() => {
+        throw new Error('Test error');
+      });
+      
+      const result = getFileDownloadUrl(mockFileId);
+      
+      expect(storage.getFileDownload).toHaveBeenCalledWith(STORAGE_FILE_BUCKET_ID, mockFileId);
+      expect(result).toBe('');
+    });
+  });
+});

--- a/src/services/__tests__/resumeService.test.ts
+++ b/src/services/__tests__/resumeService.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the appwrite modules
+vi.mock('../appwrite', () => {
+  return {
+    databases: {
+      listDocuments: vi.fn(),
+      createDocument: vi.fn(),
+      updateDocument: vi.fn(),
+      getDocument: vi.fn(),
+      deleteDocument: vi.fn(),
+    },
+    storage: {
+      createFile: vi.fn(),
+      deleteFile: vi.fn(),
+    },
+    DATABASE_ID: 'test-db-id',
+    STORAGE_FILE_BUCKET_ID: 'test-bucket-id',
+    COLLECTION_RESUME_ID: 'test-resume-collection-id',
+    ID: {
+      unique: vi.fn().mockReturnValue('unique-id'),
+    },
+    Query: {
+      orderDesc: (field) => `{"method":"orderDesc","attribute":"${field}"}`,
+      equal: (field, value) => `{"method":"equal","attribute":"${field}","values":[${value}]}`,
+      limit: (value) => `{"method":"limit","values":[${value}]}`,
+    },
+  };
+});
+
+import { databases, storage, DATABASE_ID, STORAGE_FILE_BUCKET_ID, COLLECTION_RESUME_ID, Query } from '../appwrite';
+import { 
+  getResumeVersions, 
+  getActiveResumeVersion, 
+  addResumeVersion,
+  setResumeAsActive
+} from '../resumeService';
+
+describe('resumeService', () => {
+  const mockResumeVersions = [
+    {
+      $id: 'resume-1',
+      fileId: 'file-1',
+      fileName: 'resume1.pdf',
+      uploadDate: '2023-01-01T00:00:00.000Z',
+      isActive: true,
+      description: 'First resume',
+    },
+    {
+      $id: 'resume-2',
+      fileId: 'file-2',
+      fileName: 'resume2.pdf',
+      uploadDate: '2023-02-01T00:00:00.000Z',
+      isActive: false,
+      description: 'Second resume',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getResumeVersions', () => {
+    it('should return resume versions sorted by upload date', async () => {
+      (databases.listDocuments as any).mockResolvedValue({
+        documents: mockResumeVersions,
+      });
+
+      const result = await getResumeVersions();
+
+      expect(databases.listDocuments).toHaveBeenCalledWith(
+        DATABASE_ID,
+        COLLECTION_RESUME_ID,
+        [Query.orderDesc('uploadDate')]
+      );
+      expect(result).toEqual(mockResumeVersions);
+    });
+
+    it('should return empty array when an error occurs', async () => {
+      (databases.listDocuments as any).mockRejectedValue(new Error('Test error'));
+
+      const result = await getResumeVersions();
+
+      expect(databases.listDocuments).toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getActiveResumeVersion', () => {
+    it('should return the active resume version', async () => {
+      const activeResume = mockResumeVersions[0];
+      (databases.listDocuments as any).mockResolvedValue({
+        documents: [activeResume],
+      });
+
+      const result = await getActiveResumeVersion();
+
+      expect(databases.listDocuments).toHaveBeenCalledWith(
+        DATABASE_ID,
+        COLLECTION_RESUME_ID,
+        [Query.equal('isActive', true), Query.limit(1)]
+      );
+      expect(result).toEqual(activeResume);
+    });
+
+    it('should return null when no active resume is found', async () => {
+      (databases.listDocuments as any).mockResolvedValue({
+        documents: [],
+      });
+
+      const result = await getActiveResumeVersion();
+
+      expect(databases.listDocuments).toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it('should return null when an error occurs', async () => {
+      (databases.listDocuments as any).mockRejectedValue(new Error('Test error'));
+
+      const result = await getActiveResumeVersion();
+
+      expect(databases.listDocuments).toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom';
+
+// Mock window.matchMedia which is not implemented in JSDOM
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock IntersectionObserver which is not implemented in JSDOM
+class MockIntersectionObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+});
+
+// Mock scrollTo which is not implemented in JSDOM
+window.scrollTo = vi.fn();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+  },
+});


### PR DESCRIPTION
## Description
This PR adds unit tests to the repository to increase test coverage. The focus is on testing the service layer, particularly the file proxy and resume services.

## Changes Made
- Set up Vitest testing framework with JSDOM for React components
- Added test setup with mocks for browser APIs not available in JSDOM
- Created unit tests for:
  - `fileProxy.ts` (100% coverage)
  - `validateFileType` utility in `appwrite.ts`
  - `getResumeVersions` and `getActiveResumeVersion` in `resumeService.ts`
- Added test scripts to package.json:
  - `test`: Run all tests once
  - `test:watch`: Run tests in watch mode
  - `test:coverage`: Generate test coverage report

## Benefits
- Improves code reliability through automated testing
- Provides documentation of expected behavior
- Makes future refactoring safer with test coverage
- Establishes a testing pattern for future development

## Testing
All tests are passing. The test coverage report shows 100% coverage for the `fileProxy.ts` service.

## Screenshots
N/A